### PR TITLE
[Fix] CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,9 @@ jobs:
           key: node_modules-{{ checksum "yarn.lock" }}-{{ checksum "package.json" }}-{{ arch }}
           paths:
             - node_modules
-          persist_to_workspace:
-            -root: .
-            -paths: .
+      - persist_to_workspace:
+          -root: .
+          -paths: .
 
   "Test: lint":
     <<: *defaults


### PR DESCRIPTION
Circle should save fetched modules to a workspace.