### PR TITLE
Remove error when empty for multi[Remove|Set]

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
+++ b/android/src/main/java/com/reactnativecommunity/asyncstorage/AsyncStorageModule.java
@@ -196,7 +196,7 @@ public final class AsyncStorageModule
   @ReactMethod
   public void multiSet(final ReadableArray keyValueArray, final Callback callback) {
     if (keyValueArray.size() == 0) {
-      callback.invoke(AsyncStorageErrorUtil.getInvalidKeyError(null));
+      callback.invoke();
       return;
     }
 
@@ -261,7 +261,7 @@ public final class AsyncStorageModule
   @ReactMethod
   public void multiRemove(final ReadableArray keys, final Callback callback) {
     if (keys.size() == 0) {
-      callback.invoke(AsyncStorageErrorUtil.getInvalidKeyError(null));
+      callback.invoke();
       return;
     }
 


### PR DESCRIPTION
Fixes #6 by just invoking the callback without the error.