### PR TITLE
feat: Allow brownfield iOS apps to handle storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ getData = async () => {
 
 ```
 
-See docs for [api and more examples.](docs/API.md)
+See docs for [api and more examples](docs/API.md), and [some advanced usage](docs/AdvancedUsage.md).
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ getData = async () => {
 
 ```
 
-See docs for [api and more examples](docs/API.md), and [some advanced usage](docs/AdvancedUsage.md).
+See docs for [api and more examples](docs/API.md), and [brownfield integration guide](docs/AdvancedUsage.md).
 
 ## Writing tests
 

--- a/docs/AdvancedUsage.md
+++ b/docs/AdvancedUsage.md
@@ -1,0 +1,82 @@
+# Advanced Usage
+
+## Integrating with Existing Storage Solutions in Hybrid Apps
+
+### iOS
+
+On iOS, AsyncStorage can be controlled by the hosting app via the delegate on
+`RNCAsyncStorage`:
+
+```objc
+RNCAsyncStorage *asyncStorage = [bridge moduleForClass:[RNCAsyncStorage class]];
+asyncStorage.delegate = self;
+```
+
+The delegate must conform to the protocol `RNCAsyncStorageDelegate`:
+
+```objc
+- (void)allKeys:(RNCAsyncStorageResultCallback)block;
+```
+
+Returns all keys currently stored. If none, an empty array is returned.
+Called by `getAllKeys` in JS.
+
+<br />
+
+```objc
+- (void)mergeValues:(NSArray<NSString *> *)values
+            forKeys:(NSArray<NSString *> *)keys
+         completion:(RNCAsyncStorageResultCallback)block;
+```
+
+Merges values with the corresponding values stored at specified keys.
+Called by `mergeItem` and `multiMerge` in JS.
+
+<br />
+
+```objc
+- (void)removeAllValues:(RNCAsyncStorageCompletion)block;
+```
+
+Removes all values from the store. Called by `clear` in JS.
+
+<br />
+
+```objc
+- (void)removeValuesForKeys:(NSArray<NSString *> *)keys
+                 completion:(RNCAsyncStorageResultCallback)block;
+```
+
+Removes all values associated with specified keys.
+Called by `removeItem` and `multiRemove` in JS.
+
+<br />
+
+```objc
+- (void)setValues:(NSArray<NSString *> *)values
+          forKeys:(NSArray<NSString *> *)keys
+       completion:(RNCAsyncStorageResultCallback)block;
+```
+
+Sets specified key-value pairs. Called by `setItem` and `multiSet` in JS.
+
+<br />
+
+```objc
+- (void)valuesForKeys:(NSArray<NSString *> *)keys
+           completion:(RNCAsyncStorageResultCallback)block;
+```
+
+Returns values associated with specified keys.
+Called by `getItem` and `multiGet` in JS.
+
+<br />
+
+```objc
+@optional
+@property (nonatomic, readonly, getter=isPassthrough) BOOL passthrough;
+```
+
+**Optional:** Returns whether the delegate should be treated as a passthrough.
+This is useful for monitoring storage usage among other things. Returns `NO` by
+default.

--- a/docs/AdvancedUsage.md
+++ b/docs/AdvancedUsage.md
@@ -1,6 +1,6 @@
 # Advanced Usage
 
-## Integrating with Existing Storage Solutions in Hybrid Apps
+## Integrating with Existing Storage Solutions in RN Brownfield Apps
 
 ### iOS
 

--- a/docs/AdvancedUsage.md
+++ b/docs/AdvancedUsage.md
@@ -21,7 +21,7 @@ The delegate must conform to the protocol `RNCAsyncStorageDelegate`:
 Returns all keys currently stored. If none, an empty array is returned.
 Called by `getAllKeys` in JS.
 
-<br />
+---
 
 ```objc
 - (void)mergeValues:(NSArray<NSString *> *)values
@@ -32,7 +32,7 @@ Called by `getAllKeys` in JS.
 Merges values with the corresponding values stored at specified keys.
 Called by `mergeItem` and `multiMerge` in JS.
 
-<br />
+---
 
 ```objc
 - (void)removeAllValues:(RNCAsyncStorageCompletion)block;
@@ -40,7 +40,7 @@ Called by `mergeItem` and `multiMerge` in JS.
 
 Removes all values from the store. Called by `clear` in JS.
 
-<br />
+---
 
 ```objc
 - (void)removeValuesForKeys:(NSArray<NSString *> *)keys
@@ -50,7 +50,7 @@ Removes all values from the store. Called by `clear` in JS.
 Removes all values associated with specified keys.
 Called by `removeItem` and `multiRemove` in JS.
 
-<br />
+---
 
 ```objc
 - (void)setValues:(NSArray<NSString *> *)values
@@ -60,7 +60,7 @@ Called by `removeItem` and `multiRemove` in JS.
 
 Sets specified key-value pairs. Called by `setItem` and `multiSet` in JS.
 
-<br />
+---
 
 ```objc
 - (void)valuesForKeys:(NSArray<NSString *> *)keys
@@ -70,7 +70,7 @@ Sets specified key-value pairs. Called by `setItem` and `multiSet` in JS.
 Returns values associated with specified keys.
 Called by `getItem` and `multiGet` in JS.
 
-<br />
+---
 
 ```objc
 @optional

--- a/docs/AdvancedUsage.md
+++ b/docs/AdvancedUsage.md
@@ -1,10 +1,11 @@
-# Advanced Usage
+# Integrating Async Storage with embedded React Native apps
 
-## Integrating with Existing Storage Solutions in RN Brownfield Apps
+If you're embedding React Native into native application, you can also integrate
+Async Storage module, so that both worlds will use one storage solution.
 
-### iOS
+## iOS
 
-On iOS, AsyncStorage can be controlled by the hosting app via the delegate on
+AsyncStorage can be controlled by the hosting app via the delegate on
 `RNCAsyncStorage`:
 
 ```objc
@@ -12,7 +13,11 @@ RNCAsyncStorage *asyncStorage = [bridge moduleForClass:[RNCAsyncStorage class]];
 asyncStorage.delegate = self;
 ```
 
-The delegate must conform to the protocol `RNCAsyncStorageDelegate`:
+### The procotol
+
+The delegate must conform to the `RNCAsyncStorageDelegate` protocol
+
+---
 
 ```objc
 - (void)allKeys:(RNCAsyncStorageResultCallback)block;

--- a/example/e2e/asyncstorage.e2e.js
+++ b/example/e2e/asyncstorage.e2e.js
@@ -30,7 +30,9 @@ describe('Async Storage', () => {
 
   describe('get / set / clear item test', () => {
     beforeAll(async () => {
-      await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
+      if (device.getPlatform() === 'ios') {
+        await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
+      }
     });
 
     it('should be visible', async () => {
@@ -71,7 +73,9 @@ describe('Async Storage', () => {
 
   describe('merge item test', () => {
     beforeAll(async () => {
-      await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
+      if (device.getPlatform() === 'ios') {
+        await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
+      }
     });
 
     it('should be visible', async () => {
@@ -151,7 +155,9 @@ describe('Async Storage', () => {
 
   describe('get / set / clear item delegate test', () => {
     beforeAll(async () => {
-      await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
+      if (device.getPlatform() === 'ios') {
+        await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
+      }
     });
 
     it('should be visible', async () => {
@@ -192,7 +198,9 @@ describe('Async Storage', () => {
 
   describe('merge item delegate test', () => {
     beforeAll(async () => {
-      await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
+      if (device.getPlatform() === 'ios') {
+        await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
+      }
     });
 
     it('should be visible', async () => {
@@ -207,6 +215,11 @@ describe('Async Storage', () => {
     });
 
     it('should crash when merging items in async storage', async () => {
+      if (device.getPlatform() === 'android') {
+        // Not yet supported.
+        return;
+      }
+
       const buttonMergeItem = await element(by.id('mergeItem_button'));
       try {
         await buttonMergeItem.tap();

--- a/example/e2e/asyncstorage.e2e.js
+++ b/example/e2e/asyncstorage.e2e.js
@@ -160,13 +160,6 @@ describe('Async Storage', () => {
       }
     });
 
-    it('should be visible', async () => {
-      await test_getSetClear.tap();
-      await expect(element(by.id('clear_button'))).toExist();
-      await expect(element(by.id('increaseByTen_button'))).toExist();
-      await expect(element(by.id('storedNumber_text'))).toExist();
-    });
-
     it('should store value in async storage', async () => {
       const storedNumberText = await element(by.id('storedNumber_text'));
       const increaseByTenButton = await element(by.id('increaseByTen_button'));
@@ -201,17 +194,6 @@ describe('Async Storage', () => {
       if (device.getPlatform() === 'ios') {
         await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
       }
-    });
-
-    it('should be visible', async () => {
-      await test_mergeItem.tap();
-      await expect(element(by.id('saveItem_button'))).toExist();
-      await expect(element(by.id('mergeItem_button'))).toExist();
-      await expect(element(by.id('restoreItem_button'))).toExist();
-      await expect(element(by.id('testInput-name'))).toExist();
-      await expect(element(by.id('testInput-age'))).toExist();
-      await expect(element(by.id('testInput-eyes'))).toExist();
-      await expect(element(by.id('testInput-shoe'))).toExist();
     });
 
     it('should crash when merging items in async storage', async () => {

--- a/example/e2e/asyncstorage.e2e.js
+++ b/example/e2e/asyncstorage.e2e.js
@@ -29,12 +29,17 @@ describe('Async Storage', () => {
   });
 
   describe('get / set / clear item test', () => {
+    beforeAll(async () => {
+      await device.openURL({ url: 'rnc-asyncstorage://unset-delegate' });
+    });
+
     it('should be visible', async () => {
       await test_getSetClear.tap();
       await expect(element(by.id('clear_button'))).toExist();
       await expect(element(by.id('increaseByTen_button'))).toExist();
       await expect(element(by.id('storedNumber_text'))).toExist();
     });
+
     it('should store value in async storage', async () => {
       const storedNumberText = await element(by.id('storedNumber_text'));
       const increaseByTenButton = await element(by.id('increaseByTen_button'));
@@ -65,6 +70,10 @@ describe('Async Storage', () => {
   });
 
   describe('merge item test', () => {
+    beforeAll(async () => {
+      await device.openURL({ url: 'rnc-asyncstorage://unset-delegate' });
+    });
+
     it('should be visible', async () => {
       await test_mergeItem.tap();
       await expect(element(by.id('saveItem_button'))).toExist();
@@ -137,6 +146,74 @@ describe('Async Storage', () => {
       await restartButton.tap();
       await buttonRestoreItem.tap();
       expect(storyText).toHaveText(newStory);
+    });
+  });
+
+  describe('get / set / clear item delegate test', () => {
+    beforeAll(async () => {
+      await device.openURL({ url: 'rnc-asyncstorage://set-delegate' });
+    });
+
+    it('should be visible', async () => {
+      await test_getSetClear.tap();
+      await expect(element(by.id('clear_button'))).toExist();
+      await expect(element(by.id('increaseByTen_button'))).toExist();
+      await expect(element(by.id('storedNumber_text'))).toExist();
+    });
+
+    it('should store value in async storage', async () => {
+      const storedNumberText = await element(by.id('storedNumber_text'));
+      const increaseByTenButton = await element(by.id('increaseByTen_button'));
+
+      await expect(storedNumberText).toHaveText('');
+
+      const tapTimes = Math.round(Math.random() * 9) + 1;
+
+      for (let i = 0; i < tapTimes; i++) {
+        await increaseByTenButton.tap();
+      }
+
+      await expect(storedNumberText).toHaveText(`${tapTimes * 10}`);
+      await restartButton.tap();
+      await expect(storedNumberText).toHaveText(`${tapTimes * 10}`);
+    });
+
+    it('should clear item', async () => {
+      const storedNumberText = await element(by.id('storedNumber_text'));
+      const increaseByTenButton = await element(by.id('increaseByTen_button'));
+      const clearButton = await element(by.id('clear_button'));
+
+      await increaseByTenButton.tap();
+      await clearButton.tap();
+      await restartButton.tap();
+      await expect(storedNumberText).toHaveText('');
+    });
+  });
+
+  describe('merge item delegate test', () => {
+    beforeAll(async () => {
+      await device.openURL({ url: 'rnc-asyncstorage://set-delegate' });
+    });
+
+    it('should be visible', async () => {
+      await test_mergeItem.tap();
+      await expect(element(by.id('saveItem_button'))).toExist();
+      await expect(element(by.id('mergeItem_button'))).toExist();
+      await expect(element(by.id('restoreItem_button'))).toExist();
+      await expect(element(by.id('testInput-name'))).toExist();
+      await expect(element(by.id('testInput-age'))).toExist();
+      await expect(element(by.id('testInput-eyes'))).toExist();
+      await expect(element(by.id('testInput-shoe'))).toExist();
+    });
+
+    it('should crash when merging items in async storage', async () => {
+      const buttonMergeItem = await element(by.id('mergeItem_button'));
+      try {
+        await buttonMergeItem.tap();
+        fail();
+      } catch {
+        // Expected
+      }
     });
   });
 });

--- a/example/e2e/asyncstorage.e2e.js
+++ b/example/e2e/asyncstorage.e2e.js
@@ -30,7 +30,7 @@ describe('Async Storage', () => {
 
   describe('get / set / clear item test', () => {
     beforeAll(async () => {
-      await device.openURL({ url: 'rnc-asyncstorage://unset-delegate' });
+      await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
     });
 
     it('should be visible', async () => {
@@ -71,7 +71,7 @@ describe('Async Storage', () => {
 
   describe('merge item test', () => {
     beforeAll(async () => {
-      await device.openURL({ url: 'rnc-asyncstorage://unset-delegate' });
+      await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
     });
 
     it('should be visible', async () => {
@@ -151,7 +151,7 @@ describe('Async Storage', () => {
 
   describe('get / set / clear item delegate test', () => {
     beforeAll(async () => {
-      await device.openURL({ url: 'rnc-asyncstorage://set-delegate' });
+      await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
     });
 
     it('should be visible', async () => {
@@ -192,7 +192,7 @@ describe('Async Storage', () => {
 
   describe('merge item delegate test', () => {
     beforeAll(async () => {
-      await device.openURL({ url: 'rnc-asyncstorage://set-delegate' });
+      await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
     });
 
     it('should be visible', async () => {
@@ -210,6 +210,9 @@ describe('Async Storage', () => {
       const buttonMergeItem = await element(by.id('mergeItem_button'));
       try {
         await buttonMergeItem.tap();
+
+        // Not quite sure why ESLint thinks Jest hasn't defined fail().
+        // eslint-disable-next-line no-undef
         fail();
       } catch {
         // Expected

--- a/example/e2e/asyncstorage.e2e.js
+++ b/example/e2e/asyncstorage.e2e.js
@@ -33,10 +33,10 @@ describe('Async Storage', () => {
       if (device.getPlatform() === 'ios') {
         await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
       }
+      await test_getSetClear.tap();
     });
 
     it('should be visible', async () => {
-      await test_getSetClear.tap();
       await expect(element(by.id('clear_button'))).toExist();
       await expect(element(by.id('increaseByTen_button'))).toExist();
       await expect(element(by.id('storedNumber_text'))).toExist();
@@ -76,10 +76,10 @@ describe('Async Storage', () => {
       if (device.getPlatform() === 'ios') {
         await device.openURL({url: 'rnc-asyncstorage://unset-delegate'});
       }
+      await test_mergeItem.tap();
     });
 
     it('should be visible', async () => {
-      await test_mergeItem.tap();
       await expect(element(by.id('saveItem_button'))).toExist();
       await expect(element(by.id('mergeItem_button'))).toExist();
       await expect(element(by.id('restoreItem_button'))).toExist();

--- a/example/e2e/asyncstorage.e2e.js
+++ b/example/e2e/asyncstorage.e2e.js
@@ -158,6 +158,7 @@ describe('Async Storage', () => {
       if (device.getPlatform() === 'ios') {
         await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
       }
+      await test_getSetClear.tap();
     });
 
     it('should store value in async storage', async () => {
@@ -194,6 +195,7 @@ describe('Async Storage', () => {
       if (device.getPlatform() === 'ios') {
         await device.openURL({url: 'rnc-asyncstorage://set-delegate'});
       }
+      await test_mergeItem.tap();
     });
 
     it('should crash when merging items in async storage', async () => {

--- a/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
+++ b/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
@@ -84,6 +84,13 @@
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
+		1990B95122398FC4009E5EA1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3DC5395A220F2C940035D3A3 /* RNCAsyncStorage.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 58B511DA1A9E6C8500147676;
+			remoteInfo = RNCAsyncStorage;
+		};
 		2D16E6711FA4F8DC00B85C8A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */;
@@ -329,11 +336,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				3D82E3B72248BD39001F5D1A /* libRNCAsyncStorage.a in Frameworks */,
-				ED297163215061F000B7C4FE /* JavaScriptCore.framework in Frameworks */,
-				ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */,
-				11D1A2F320CAFA9E000508D9 /* libRCTAnimation.a in Frameworks */,
-				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
+				11D1A2F320CAFA9E000508D9 /* libRCTAnimation.a in Frameworks */,
+				ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */,
 				00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */,
 				00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */,
 				133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */,
@@ -342,6 +347,8 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				146834051AC3E58100842450 /* libReact.a in Frameworks */,
+				ED297163215061F000B7C4FE /* JavaScriptCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -557,6 +564,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1990B95222398FC4009E5EA1 /* PBXTargetDependency */,
 			);
 			name = AsyncStorageExample;
 			productName = "Hello World";
@@ -938,7 +946,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../../node_modules/react-native/scripts/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -953,6 +961,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1990B95222398FC4009E5EA1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RNCAsyncStorage;
+			targetProxy = 1990B95122398FC4009E5EA1 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		13B07FB11A68108700A75B9A /* LaunchScreen.xib */ = {

--- a/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
+++ b/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		196F5D682254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 196F5D672254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m */; };
 		3D82E3B72248BD39001F5D1A /* libRNCAsyncStorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DC5398C220F2C940035D3A3 /* libRNCAsyncStorage.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
@@ -320,6 +321,8 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = AsyncStorageExample/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = AsyncStorageExample/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
+		196F5D672254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "AppDelegate+RNCAsyncStorageDelegate.m"; path = "AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.m"; sourceTree = "<group>"; };
+		196F5D8E2254C2C90035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "AppDelegate+RNCAsyncStorageDelegate.h"; path = "AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.h"; sourceTree = "<group>"; };
 		2D16E6891FA4F8E400B85C8A /* libReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DC5395A220F2C940035D3A3 /* RNCAsyncStorage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNCAsyncStorage.xcodeproj; path = ../../ios/RNCAsyncStorage.xcodeproj; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
@@ -423,6 +426,8 @@
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
+				196F5D8E2254C2C90035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.h */,
+				196F5D672254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
@@ -957,6 +962,7 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				196F5D682254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
+++ b/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		196F5D682254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 196F5D672254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m */; };
+		19C469542256303E00CA1332 /* RNCTestAsyncStorageDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 19C469532256303E00CA1332 /* RNCTestAsyncStorageDelegate.m */; };
 		3D82E3B72248BD39001F5D1A /* libRNCAsyncStorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DC5398C220F2C940035D3A3 /* libRNCAsyncStorage.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
@@ -323,6 +324,8 @@
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		196F5D672254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = "AppDelegate+RNCAsyncStorageDelegate.m"; path = "AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.m"; sourceTree = "<group>"; };
 		196F5D8E2254C2C90035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "AppDelegate+RNCAsyncStorageDelegate.h"; path = "AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.h"; sourceTree = "<group>"; };
+		19C4692D22562FD400CA1332 /* RNCTestAsyncStorageDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RNCTestAsyncStorageDelegate.h; path = AsyncStorageExample/RNCTestAsyncStorageDelegate.h; sourceTree = "<group>"; };
+		19C469532256303E00CA1332 /* RNCTestAsyncStorageDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RNCTestAsyncStorageDelegate.m; path = AsyncStorageExample/RNCTestAsyncStorageDelegate.m; sourceTree = "<group>"; };
 		2D16E6891FA4F8E400B85C8A /* libReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3DC5395A220F2C940035D3A3 /* RNCAsyncStorage.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNCAsyncStorage.xcodeproj; path = ../../ios/RNCAsyncStorage.xcodeproj; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
@@ -428,6 +431,8 @@
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
 				196F5D8E2254C2C90035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.h */,
 				196F5D672254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m */,
+				19C4692D22562FD400CA1332 /* RNCTestAsyncStorageDelegate.h */,
+				19C469532256303E00CA1332 /* RNCTestAsyncStorageDelegate.m */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
@@ -961,6 +966,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				19C469542256303E00CA1332 /* RNCTestAsyncStorageDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				196F5D682254C1530035A6D3 /* AppDelegate+RNCAsyncStorageDelegate.m in Sources */,
 			);

--- a/example/ios/AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.h
+++ b/example/ios/AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.h
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "AppDelegate.h"
+
+#import <RNCAsyncStorage/RNCAsyncStorageDelegate.h>
+
+@interface AppDelegate (RNCAsyncStorageDelegate) <RNCAsyncStorageDelegate>
+@end

--- a/example/ios/AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.m
+++ b/example/ios/AsyncStorageExample/AppDelegate+RNCAsyncStorageDelegate.m
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "AppDelegate+RNCAsyncStorageDelegate.h"
+
+#import <RNCAsyncStorage/RNCAsyncStorage.h>
+
+@implementation AppDelegate (RNCAsyncStorageDelegate)
+
+- (void)allKeys:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  completion(self.memoryStorage.allKeys);
+}
+
+- (void)mergeValues:(nonnull NSArray<NSString *> *)values
+            forKeys:(nonnull NSArray<NSString *> *)keys
+         completion:(nonnull RNCAsyncStorageResultCallback)block
+{
+  [NSException raise:@"Unimplemented"
+              format:@"%@ is unimplemented", NSStringFromSelector(_cmd)];
+}
+
+- (void)removeAllValues:(nonnull RNCAsyncStorageCompletion)completion
+{
+  [self.memoryStorage removeAllObjects];
+  completion(nil);
+}
+
+- (void)removeValuesForKeys:(nonnull NSArray<NSString *> *)keys
+                 completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  for (NSString *key in keys) {
+    [self.memoryStorage removeObjectForKey:key];
+  }
+  completion(@[]);
+}
+
+- (void)setValues:(nonnull NSArray<NSString *> *)values
+          forKeys:(nonnull NSArray<NSString *> *)keys
+       completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  for (NSUInteger i = 0; i < values.count; ++i) {
+    NSString *value = values[i];
+    NSString *key = keys[i];
+    [self.memoryStorage setObject:value forKey:key];
+  }
+  completion(@[]);
+}
+
+- (void)valuesForKeys:(nonnull NSArray<NSString *> *)keys
+           completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  NSMutableArray *values = [NSMutableArray arrayWithCapacity:keys.count];
+  for (NSString *key in keys) {
+    NSString *value = self.memoryStorage[key];
+    [values addObject:value == nil ? [NSNull null] : value];
+  }
+  completion(values);
+}
+
+@end

--- a/example/ios/AsyncStorageExample/AppDelegate.h
+++ b/example/ios/AsyncStorageExample/AppDelegate.h
@@ -7,7 +7,9 @@
 
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+#import <RNCAsyncStorage/RNCAsyncStorageDelegate.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate, RNCAsyncStorageDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 

--- a/example/ios/AsyncStorageExample/AppDelegate.h
+++ b/example/ios/AsyncStorageExample/AppDelegate.h
@@ -7,10 +7,9 @@
 
 #import <UIKit/UIKit.h>
 
-#import <RNCAsyncStorage/RNCAsyncStorageDelegate.h>
-
-@interface AppDelegate : UIResponder <UIApplicationDelegate, RNCAsyncStorageDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, NSString *> *memoryStorage;
 
 @end

--- a/example/ios/AsyncStorageExample/AppDelegate.m
+++ b/example/ios/AsyncStorageExample/AppDelegate.m
@@ -7,13 +7,22 @@
 
 #import "AppDelegate.h"
 
+#import <RNCAsyncStorage/RNCAsyncStorage.h>
 #import <React/RCTBundleURLProvider.h>
+#import <React/RCTDevMenu.h>
 #import <React/RCTRootView.h>
 
-@implementation AppDelegate
+@implementation AppDelegate {
+  NSMutableDictionary<NSString *, NSString *> *_memoryStorage;
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(didLoadJavaScript:)
+                                               name:RCTJavaScriptDidLoadNotification
+                                             object:nil];
+
   NSURL *jsCodeLocation;
 
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"example/index" fallbackResource:nil];
@@ -30,6 +39,85 @@
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
   return YES;
+}
+
+- (void)addDevMenuItemsForBridge:(RCTBridge *)bridge
+{
+  _memoryStorage = [NSMutableDictionary dictionary];
+
+  __weak AppDelegate *weakSelf = self;
+  RCTDevMenuItem *delegateToggle = [RCTDevMenuItem
+      buttonItemWithTitleBlock:^NSString * {
+        RNCAsyncStorage *asyncStorage = [bridge moduleForClass:[RNCAsyncStorage class]];
+        return asyncStorage.delegate == nil ? @"Set AsyncStorage Delegate"
+                                            : @"Unset AsyncStorage Delegate";
+      }
+      handler:^{
+        RNCAsyncStorage *asyncStorage = [bridge moduleForClass:[RNCAsyncStorage class]];
+        asyncStorage.delegate = asyncStorage.delegate == nil ? weakSelf : nil;
+      }];
+  [bridge.devMenu addItem:delegateToggle];
+}
+
+- (void)didLoadJavaScript:(NSNotification *)note
+{
+  RCTBridge *bridge = note.userInfo[@"bridge"];
+  if (bridge == nil) {
+    return;
+  }
+
+  [self addDevMenuItemsForBridge:bridge];
+}
+
+#pragma mark - RNCAsyncStorageDelegate
+
+- (void)allKeys:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  completion(_memoryStorage.allKeys);
+}
+
+- (void)mergeValues:(nonnull NSArray<NSString *> *)values
+            forKeys:(nonnull NSArray<NSString *> *)keys
+         completion:(nonnull RNCAsyncStorageResultCallback)block
+{
+}
+
+- (void)removeAllValues:(nonnull RNCAsyncStorageCompletion)completion
+{
+  [_memoryStorage removeAllObjects];
+  completion(nil);
+}
+
+- (void)removeValuesForKeys:(nonnull NSArray<NSString *> *)keys
+                 completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  for (NSString *key in keys) {
+    [_memoryStorage removeObjectForKey:key];
+  }
+  completion(@[]);
+}
+
+- (void)setValues:(nonnull NSArray<NSString *> *)values
+          forKeys:(nonnull NSArray<NSString *> *)keys
+       completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  for (NSUInteger i = 0; i < values.count; ++i) {
+    NSString *value = values[i];
+    NSString *key = keys[i];
+    [_memoryStorage setObject:value forKey:key];
+  }
+  completion(@[]);
+}
+
+- (void)valuesForKeys:(nonnull NSArray<NSString *> *)keys
+           completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  NSMutableArray *values = [NSMutableArray arrayWithCapacity:keys.count];
+  for (NSString *key in keys) {
+    NSString *value = _memoryStorage[key];
+    [values addObject:value == nil ? [NSNull null] : value];
+  }
+  completion(values);
 }
 
 @end

--- a/example/ios/AsyncStorageExample/AppDelegate.m
+++ b/example/ios/AsyncStorageExample/AppDelegate.m
@@ -14,6 +14,7 @@
 
 @implementation AppDelegate {
   NSMutableDictionary<NSString *, NSString *> *_memoryStorage;
+  __weak RCTBridge *_bridge;
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -66,7 +67,27 @@
     return;
   }
 
+  _bridge = bridge;
   [self addDevMenuItemsForBridge:bridge];
+}
+
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
+{
+  if (![url.scheme isEqualToString:@"rnc-asyncstorage"]) {
+    return NO;
+  }
+
+  if ([url.host isEqualToString:@"set-delegate"]) {
+    RNCAsyncStorage *asyncStorage = [_bridge moduleForClass:[RNCAsyncStorage class]];
+    asyncStorage.delegate = self;
+  } else if ([url.host isEqualToString:@"unset-delegate"]) {
+    RNCAsyncStorage *asyncStorage = [_bridge moduleForClass:[RNCAsyncStorage class]];
+    asyncStorage.delegate = nil;
+  }
+
+  return YES;
 }
 
 #pragma mark - RNCAsyncStorageDelegate
@@ -80,6 +101,8 @@
             forKeys:(nonnull NSArray<NSString *> *)keys
          completion:(nonnull RNCAsyncStorageResultCallback)block
 {
+  [NSException raise:@"Unimplemented"
+              format:@"%@ is unimplemented", NSStringFromSelector(_cmd)];
 }
 
 - (void)removeAllValues:(nonnull RNCAsyncStorageCompletion)completion

--- a/example/ios/AsyncStorageExample/AppDelegate.m
+++ b/example/ios/AsyncStorageExample/AppDelegate.m
@@ -7,13 +7,14 @@
 
 #import "AppDelegate.h"
 
+#import "AppDelegate+RNCAsyncStorageDelegate.h"
+
 #import <RNCAsyncStorage/RNCAsyncStorage.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDevMenu.h>
 #import <React/RCTRootView.h>
 
 @implementation AppDelegate {
-  NSMutableDictionary<NSString *, NSString *> *_memoryStorage;
   __weak RCTBridge *_bridge;
 }
 
@@ -88,59 +89,6 @@
   }
 
   return YES;
-}
-
-#pragma mark - RNCAsyncStorageDelegate
-
-- (void)allKeys:(nonnull RNCAsyncStorageResultCallback)completion
-{
-  completion(_memoryStorage.allKeys);
-}
-
-- (void)mergeValues:(nonnull NSArray<NSString *> *)values
-            forKeys:(nonnull NSArray<NSString *> *)keys
-         completion:(nonnull RNCAsyncStorageResultCallback)block
-{
-  [NSException raise:@"Unimplemented"
-              format:@"%@ is unimplemented", NSStringFromSelector(_cmd)];
-}
-
-- (void)removeAllValues:(nonnull RNCAsyncStorageCompletion)completion
-{
-  [_memoryStorage removeAllObjects];
-  completion(nil);
-}
-
-- (void)removeValuesForKeys:(nonnull NSArray<NSString *> *)keys
-                 completion:(nonnull RNCAsyncStorageResultCallback)completion
-{
-  for (NSString *key in keys) {
-    [_memoryStorage removeObjectForKey:key];
-  }
-  completion(@[]);
-}
-
-- (void)setValues:(nonnull NSArray<NSString *> *)values
-          forKeys:(nonnull NSArray<NSString *> *)keys
-       completion:(nonnull RNCAsyncStorageResultCallback)completion
-{
-  for (NSUInteger i = 0; i < values.count; ++i) {
-    NSString *value = values[i];
-    NSString *key = keys[i];
-    [_memoryStorage setObject:value forKey:key];
-  }
-  completion(@[]);
-}
-
-- (void)valuesForKeys:(nonnull NSArray<NSString *> *)keys
-           completion:(nonnull RNCAsyncStorageResultCallback)completion
-{
-  NSMutableArray *values = [NSMutableArray arrayWithCapacity:keys.count];
-  for (NSString *key in keys) {
-    NSString *value = _memoryStorage[key];
-    [values addObject:value == nil ? [NSNull null] : value];
-  }
-  completion(values);
 }
 
 @end

--- a/example/ios/AsyncStorageExample/AppDelegate.m
+++ b/example/ios/AsyncStorageExample/AppDelegate.m
@@ -8,6 +8,7 @@
 #import "AppDelegate.h"
 
 #import "AppDelegate+RNCAsyncStorageDelegate.h"
+#import "RNCTestAsyncStorageDelegate.h"
 
 #import <RNCAsyncStorage/RNCAsyncStorage.h>
 #import <React/RCTBundleURLProvider.h>
@@ -16,6 +17,7 @@
 
 @implementation AppDelegate {
   __weak RCTBridge *_bridge;
+  RNCTestAsyncStorageDelegate *_testDelegate;
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
@@ -81,8 +83,11 @@
   }
 
   if ([url.host isEqualToString:@"set-delegate"]) {
+    if (_testDelegate == nil) {
+      _testDelegate = [RNCTestAsyncStorageDelegate new];
+    }
     RNCAsyncStorage *asyncStorage = [_bridge moduleForClass:[RNCAsyncStorage class]];
-    asyncStorage.delegate = self;
+    asyncStorage.delegate = _testDelegate;
   } else if ([url.host isEqualToString:@"unset-delegate"]) {
     RNCAsyncStorage *asyncStorage = [_bridge moduleForClass:[RNCAsyncStorage class]];
     asyncStorage.delegate = nil;

--- a/example/ios/AsyncStorageExample/Info.plist
+++ b/example/ios/AsyncStorageExample/Info.plist
@@ -20,10 +20,36 @@
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>org.reactjs.native.example.AsyncStorageExample</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>rnc-asyncstorage</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
 	<key>UILaunchStoryboardName</key>
@@ -40,21 +66,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
-	<key>NSAppTransportSecurity</key>
-	<!--See http://ste.vn/2015/06/10/configuring-app-transport-security-ios-9-osx-10-11/ -->
-	<dict>
-    <key>NSAllowsArbitraryLoads</key>
-    <true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 </dict>
 </plist>

--- a/example/ios/AsyncStorageExample/RNCTestAsyncStorageDelegate.h
+++ b/example/ios/AsyncStorageExample/RNCTestAsyncStorageDelegate.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <RNCAsyncStorage/RNCAsyncStorageDelegate.h>
+
+/*!
+ * Implementation of |RNCAsyncStorageDelegate| used for E2E testing purposes only.
+ */
+@interface RNCTestAsyncStorageDelegate : NSObject <RNCAsyncStorageDelegate>
+@end

--- a/example/ios/AsyncStorageExample/RNCTestAsyncStorageDelegate.m
+++ b/example/ios/AsyncStorageExample/RNCTestAsyncStorageDelegate.m
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RNCTestAsyncStorageDelegate.h"
+
+const NSInteger RNCTestAsyncStorageExtraValue = 1000000;
+
+NSString *RNCTestAddExtraValue(NSString *value)
+{
+  NSInteger i = [value integerValue];
+  if (i == 0) {
+    return value;
+  }
+  return [NSString stringWithFormat:@"%ld", (long)i + RNCTestAsyncStorageExtraValue];
+}
+
+NSString *RNCTestRemoveExtraValue(NSString *value)
+{
+  NSInteger i = [value integerValue];
+  if (i > RNCTestAsyncStorageExtraValue) {
+    i -= RNCTestAsyncStorageExtraValue;
+  }
+  return [NSString stringWithFormat:@"%ld", (long)i];
+}
+
+@implementation RNCTestAsyncStorageDelegate {
+  NSMutableDictionary<NSString *, NSString *> *_memoryStorage;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _memoryStorage = [NSMutableDictionary dictionary];
+  }
+  return self;
+}
+
+- (void)allKeys:(RNCAsyncStorageResultCallback)completion
+{
+  completion(_memoryStorage.allKeys);
+}
+
+- (void)mergeValues:(nonnull NSArray<NSString *> *)values
+            forKeys:(nonnull NSArray<NSString *> *)keys
+         completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  NSError *error = nil;
+  NSDictionary *dictionary =
+      [NSJSONSerialization JSONObjectWithData:[values[0] dataUsingEncoding:NSUTF8StringEncoding]
+                                      options:NSJSONReadingMutableContainers
+                                        error:&error];
+  NSMutableDictionary *modified = [NSMutableDictionary dictionaryWithCapacity:dictionary.count];
+  for (NSString *key in dictionary) {
+    NSObject *value = dictionary[key];
+    if ([value isKindOfClass:[NSString class]]) {
+      modified[key] = [(NSString *)value stringByAppendingString:@" from delegate"];
+    } else {
+      modified[key] = value;
+    }
+  }
+
+  NSData *data = [NSJSONSerialization dataWithJSONObject:modified options:0 error:&error];
+  NSString *str = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+  _memoryStorage[keys[0]] = str;
+  completion(@[str]);
+}
+
+- (void)removeAllValues:(nonnull RNCAsyncStorageCompletion)completion
+{
+  [_memoryStorage removeAllObjects];
+  completion(nil);
+}
+
+- (void)removeValuesForKeys:(nonnull NSArray<NSString *> *)keys
+                 completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  for (NSString *key in keys) {
+    [_memoryStorage
+        setObject:[NSString stringWithFormat:@"%ld", (long)RNCTestAsyncStorageExtraValue]
+           forKey:key];
+  }
+  completion(@[]);
+}
+
+- (void)setValues:(nonnull NSArray<NSString *> *)values
+          forKeys:(nonnull NSArray<NSString *> *)keys
+       completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  for (NSUInteger i = 0; i < values.count; ++i) {
+    NSString *value = values[i];
+    NSString *key = keys[i];
+    [_memoryStorage setObject:RNCTestRemoveExtraValue(value) forKey:key];
+  }
+  completion(@[]);
+}
+
+- (void)valuesForKeys:(nonnull NSArray<NSString *> *)keys
+           completion:(nonnull RNCAsyncStorageResultCallback)completion
+{
+  NSMutableArray *values = [NSMutableArray arrayWithCapacity:keys.count];
+  for (NSString *key in keys) {
+    NSString *value = _memoryStorage[key];
+    [values addObject:value == nil ? [NSNull null] : RNCTestAddExtraValue(value)];
+  }
+  completion(values);
+}
+
+@end

--- a/ios/RNCAsyncStorage.h
+++ b/ios/RNCAsyncStorage.h
@@ -7,6 +7,7 @@
 
 #import <React/RCTBridgeModule.h>
 #import <React/RCTInvalidating.h>
+#import <RNCAsyncStorage/RNCAsyncStorageDelegate.h>
 
 /**
  * A simple, asynchronous, persistent, key-value storage system designed as a
@@ -20,6 +21,8 @@
  * Keys and values must always be strings or an error is returned.
  */
 @interface RNCAsyncStorage : NSObject <RCTBridgeModule,RCTInvalidating>
+
+@property (nonatomic, weak, nullable) id<RNCAsyncStorageDelegate> delegate;
 
 @property (nonatomic, assign) BOOL clearOnInvalidate;
 
@@ -36,6 +39,5 @@
 
 // Add multiple key value pairs to the cache.
 - (void)multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs callback:(RCTResponseSenderBlock)callback;
-
 
 @end

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -357,6 +357,11 @@ RCT_EXPORT_MODULE()
   callback(@[RCTNullIfNil(errors), result]);
 }
 
+- (BOOL)_passthroughDelegate
+{
+    return [self.delegate respondsToSelector:@selector(isPassthrough)] && self.delegate.isPassthrough;
+}
+
 #pragma mark - Exported JS Functions
 
 RCT_EXPORT_METHOD(multiGet:(NSArray<NSString *> *)keys
@@ -380,7 +385,10 @@ RCT_EXPORT_METHOD(multiGet:(NSArray<NSString *> *)keys
                         }
                       }];
     }];
-    return;
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
   }
 
   NSDictionary *errorOut = [self _ensureSetup];
@@ -409,7 +417,10 @@ RCT_EXPORT_METHOD(multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
       NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
       callback(@[RCTNullIfNil(errors)]);
     }];
-    return;
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
   }
 
   NSDictionary *errorOut = [self _ensureSetup];
@@ -443,7 +454,10 @@ RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
       NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
       callback(@[RCTNullIfNil(errors)]);
     }];
-    return;
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
   }
 
   NSDictionary *errorOut = [self _ensureSetup];
@@ -487,7 +501,10 @@ RCT_EXPORT_METHOD(multiRemove:(NSArray<NSString *> *)keys
       NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
       callback(@[RCTNullIfNil(errors)]);
     }];
-    return;
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
   }
 
   NSDictionary *errorOut = [self _ensureSetup];
@@ -543,7 +560,10 @@ RCT_EXPORT_METHOD(getAllKeys:(RCTResponseSenderBlock)callback)
     [self.delegate allKeys:^(NSArray<id<NSObject>> *keys) {
       callback(@[(id)kCFNull, keys]);
     }];
-    return;
+
+    if (![self _passthroughDelegate]) {
+      return;
+    }
   }
 
   NSDictionary *errorOut = [self _ensureSetup];

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -43,6 +43,18 @@ static void RCTAppendError(NSDictionary *error, NSMutableArray<NSDictionary *> *
   }
 }
 
+static NSArray<NSDictionary *> *RCTMakeErrors(NSArray<id<NSObject>> *results) {
+  NSMutableArray<NSDictionary *> *errors;
+  for (id object in results) {
+    if ([object isKindOfClass:[NSError class]]) {
+      NSError *error = (NSError *)object;
+      NSDictionary *keyError = RCTMakeError(error.localizedDescription, error, nil);
+      RCTAppendError(keyError, &errors);
+    }
+  }
+  return errors;
+}
+
 static NSString *RCTReadFile(NSString *filePath, NSString *key, NSDictionary **errorOut)
 {
   if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
@@ -329,30 +341,77 @@ RCT_EXPORT_MODULE()
   return errorOut;
 }
 
-#pragma mark - Exported JS Functions
-
-RCT_EXPORT_METHOD(multiGet:(NSArray<NSString *> *)keys
-                  callback:(RCTResponseSenderBlock)callback)
+- (void)_multiGet:(NSArray<NSString *> *)keys
+         callback:(RCTResponseSenderBlock)callback
+           getter:(NSString *(^)(NSUInteger i, NSString *key, NSDictionary **errorOut))getValue
 {
-  NSDictionary *errorOut = [self _ensureSetup];
-  if (errorOut) {
-    callback(@[@[errorOut], (id)kCFNull]);
-    return;
-  }
   NSMutableArray<NSDictionary *> *errors;
-  NSMutableArray<NSArray<NSString *> *> *result = [[NSMutableArray alloc] initWithCapacity:keys.count];
-  for (NSString *key in keys) {
+  NSMutableArray<NSArray<NSString *> *> *result = [NSMutableArray arrayWithCapacity:keys.count];
+  for (NSUInteger i = 0; i < keys.count; ++i) {
+    NSString *key = keys[i];
     id keyError;
-    id value = [self _getValueForKey:key errorOut:&keyError];
+    id value = getValue(i, key, &keyError);
     [result addObject:@[key, RCTNullIfNil(value)]];
     RCTAppendError(keyError, &errors);
   }
   callback(@[RCTNullIfNil(errors), result]);
 }
 
+#pragma mark - Exported JS Functions
+
+RCT_EXPORT_METHOD(multiGet:(NSArray<NSString *> *)keys
+                  callback:(RCTResponseSenderBlock)callback)
+{
+  if (self.delegate != nil) {
+    [self.delegate valuesForKeys:keys completion:^(NSArray<id<NSObject>> *valuesOrErrors) {
+      [self _multiGet:keys
+             callback:callback
+               getter:^NSString *(NSUInteger i, NSString *key, NSDictionary **errorOut) {
+                        id valueOrError = valuesOrErrors[i];
+                        if ([valueOrError isKindOfClass:[NSError class]]) {
+                          NSError *error = (NSError *)valueOrError;
+                          NSDictionary *extraData = @{@"key": RCTNullIfNil(key)};
+                          *errorOut = RCTMakeError(error.localizedDescription, error, extraData);
+                          return nil;
+                        } else {
+                          return [valueOrError isKindOfClass:[NSString class]]
+                            ? (NSString *)valueOrError
+                            : nil;
+                        }
+                      }];
+    }];
+    return;
+  }
+
+  NSDictionary *errorOut = [self _ensureSetup];
+  if (errorOut) {
+    callback(@[@[errorOut], (id)kCFNull]);
+    return;
+  }
+  [self _multiGet:keys
+         callback:callback
+           getter:^(NSUInteger i, NSString *key, NSDictionary **errorOut) {
+                    return [self _getValueForKey:key errorOut:errorOut];
+                  }];
+}
+
 RCT_EXPORT_METHOD(multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
                   callback:(RCTResponseSenderBlock)callback)
 {
+  if (self.delegate != nil) {
+    NSMutableArray<NSString *> *keys = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    NSMutableArray<NSString *> *values = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    for (NSArray<NSString *> *entry in kvPairs) {
+      [keys addObject:entry[0]];
+      [values addObject:entry[1]];
+    }
+    [self.delegate setValues:values forKeys:keys completion:^(NSArray<id<NSObject>> *results) {
+      NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
+      callback(@[RCTNullIfNil(errors)]);
+    }];
+    return;
+  }
+
   NSDictionary *errorOut = [self _ensureSetup];
   if (errorOut) {
     callback(@[@[errorOut]]);
@@ -373,6 +432,20 @@ RCT_EXPORT_METHOD(multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
 RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
                     callback:(RCTResponseSenderBlock)callback)
 {
+  if (self.delegate != nil) {
+    NSMutableArray<NSString *> *keys = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    NSMutableArray<NSString *> *values = [NSMutableArray arrayWithCapacity:kvPairs.count];
+    for (NSArray<NSString *> *entry in kvPairs) {
+      [keys addObject:entry[0]];
+      [values addObject:entry[1]];
+    }
+    [self.delegate mergeValues:values forKeys:keys completion:^(NSArray<id<NSObject>> *results) {
+      NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
+      callback(@[RCTNullIfNil(errors)]);
+    }];
+    return;
+  }
+
   NSDictionary *errorOut = [self _ensureSetup];
   if (errorOut) {
     callback(@[@[errorOut]]);
@@ -407,8 +480,16 @@ RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
 }
 
 RCT_EXPORT_METHOD(multiRemove:(NSArray<NSString *> *)keys
-                  callback:(RCTResponseSenderBlock)callback)
+                     callback:(RCTResponseSenderBlock)callback)
 {
+  if (self.delegate != nil) {
+    [self.delegate removeValuesForKeys:keys completion:^(NSArray<id<NSObject>> *results) {
+      NSArray<NSDictionary *> *errors = RCTMakeErrors(results);
+      callback(@[RCTNullIfNil(errors)]);
+    }];
+    return;
+  }
+
   NSDictionary *errorOut = [self _ensureSetup];
   if (errorOut) {
     callback(@[@[errorOut]]);
@@ -439,6 +520,17 @@ RCT_EXPORT_METHOD(multiRemove:(NSArray<NSString *> *)keys
 
 RCT_EXPORT_METHOD(clear:(RCTResponseSenderBlock)callback)
 {
+  if (self.delegate != nil) {
+    [self.delegate removeAllValues:^(NSError *error) {
+      NSDictionary *result = nil;
+      if (error != nil) {
+        result = RCTMakeError(error.localizedDescription, error, nil);
+      }
+      callback(@[RCTNullIfNil(result)]);
+    }];
+    return;
+  }
+
   [_manifest removeAllObjects];
   [RCTGetCache() removeAllObjects];
   NSDictionary *error = RCTDeleteStorageDirectory();
@@ -447,6 +539,13 @@ RCT_EXPORT_METHOD(clear:(RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(getAllKeys:(RCTResponseSenderBlock)callback)
 {
+  if (self.delegate != nil) {
+    [self.delegate allKeys:^(NSArray<id<NSObject>> *keys) {
+      callback(@[(id)kCFNull, keys]);
+    }];
+    return;
+  }
+
   NSDictionary *errorOut = [self _ensureSetup];
   if (errorOut) {
     callback(@[errorOut, (id)kCFNull]);

--- a/ios/RNCAsyncStorage.xcodeproj/project.pbxproj
+++ b/ios/RNCAsyncStorage.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1990B97A223993B0009E5EA1 /* RNCAsyncStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3E7B5881CC2AC0600A0062D /* RNCAsyncStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1990B97B223993B0009E5EA1 /* RNCAsyncStorageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1990B9402233FE3A009E5EA1 /* RNCAsyncStorageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B3E7B58A1CC2AC0600A0062D /* RNCAsyncStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNCAsyncStorage.m */; };
 /* End PBXBuildFile section */
 
@@ -17,6 +19,8 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				1990B97A223993B0009E5EA1 /* RNCAsyncStorage.h in CopyFiles */,
+				1990B97B223993B0009E5EA1 /* RNCAsyncStorageDelegate.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -24,6 +28,7 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNCAsyncStorage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNCAsyncStorage.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1990B9402233FE3A009E5EA1 /* RNCAsyncStorageDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCAsyncStorageDelegate.h; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNCAsyncStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCAsyncStorage.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNCAsyncStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCAsyncStorage.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -52,17 +57,31 @@
 			children = (
 				B3E7B5881CC2AC0600A0062D /* RNCAsyncStorage.h */,
 				B3E7B5891CC2AC0600A0062D /* RNCAsyncStorage.m */,
+				1990B9402233FE3A009E5EA1 /* RNCAsyncStorageDelegate.h */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		19F94B1D2239A948006921A9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1990B97A223993B0009E5EA1 /* RNCAsyncStorage.h in Headers */,
+				1990B97B223993B0009E5EA1 /* RNCAsyncStorageDelegate.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		58B511DA1A9E6C8500147676 /* RNCAsyncStorage */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RNCAsyncStorage" */;
 			buildPhases = (
+				19F94B1D2239A948006921A9 /* Headers */,
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
 				58B511D91A9E6C8500147676 /* CopyFiles */,
@@ -204,7 +223,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",

--- a/ios/RNCAsyncStorageDelegate.h
+++ b/ios/RNCAsyncStorageDelegate.h
@@ -32,6 +32,10 @@ typedef void (^RNCAsyncStorageResultCallback)(NSArray<id<NSObject>> * valuesOrEr
 - (void)valuesForKeys:(NSArray<NSString *> *)keys
            completion:(RNCAsyncStorageResultCallback)block;
 
+@optional
+
+@property (nonatomic, readonly, getter=isPassthrough) BOOL passthrough;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/RNCAsyncStorageDelegate.h
+++ b/ios/RNCAsyncStorageDelegate.h
@@ -14,26 +14,59 @@ typedef void (^RNCAsyncStorageResultCallback)(NSArray<id<NSObject>> * valuesOrEr
 
 @protocol RNCAsyncStorageDelegate <NSObject>
 
+/*!
+ * Returns all keys currently stored. If none, an empty array is returned.
+ * @param block Block to call with result.
+ */
 - (void)allKeys:(RNCAsyncStorageResultCallback)block;
 
+/*!
+ * Merges values with the corresponding values stored at specified keys.
+ * @param values Values to merge.
+ * @param keys Keys to the values that should be merged with.
+ * @param block Block to call with merged result.
+ */
 - (void)mergeValues:(NSArray<NSString *> *)values
             forKeys:(NSArray<NSString *> *)keys
          completion:(RNCAsyncStorageResultCallback)block;
 
+/*!
+ * Removes all values from the store.
+ * @param block Block to call with result.
+ */
 - (void)removeAllValues:(RNCAsyncStorageCompletion)block;
 
+/*!
+ * Removes all values associated with specified keys.
+ * @param keys Keys of values to remove.
+ * @param block Block to call with result.
+ */
 - (void)removeValuesForKeys:(NSArray<NSString *> *)keys
                  completion:(RNCAsyncStorageResultCallback)block;
 
+/*!
+ * Sets specified key-value pairs.
+ * @param values Values to set.
+ * @param keys Keys of specified values to set.
+ * @param block Block to call with result.
+ */
 - (void)setValues:(NSArray<NSString *> *)values
           forKeys:(NSArray<NSString *> *)keys
        completion:(RNCAsyncStorageResultCallback)block;
 
+/*!
+ * Returns values associated with specified keys.
+ * @param keys Keys of values to return.
+ * @param block Block to call with result.
+ */
 - (void)valuesForKeys:(NSArray<NSString *> *)keys
            completion:(RNCAsyncStorageResultCallback)block;
 
 @optional
 
+/*!
+ * Returns whether the delegate should be treated as a passthrough.
+ */
 @property (nonatomic, readonly, getter=isPassthrough) BOOL passthrough;
 
 @end

--- a/ios/RNCAsyncStorageDelegate.h
+++ b/ios/RNCAsyncStorageDelegate.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^RNCAsyncStorageCompletion)(NSError *_Nullable error);
+typedef void (^RNCAsyncStorageResultCallback)(NSArray<id<NSObject>> * valuesOrErrors);
+
+@protocol RNCAsyncStorageDelegate <NSObject>
+
+- (void)allKeys:(RNCAsyncStorageResultCallback)block;
+
+- (void)mergeValues:(NSArray<NSString *> *)values
+            forKeys:(NSArray<NSString *> *)keys
+         completion:(RNCAsyncStorageResultCallback)block;
+
+- (void)removeAllValues:(RNCAsyncStorageCompletion)block;
+
+- (void)removeValuesForKeys:(NSArray<NSString *> *)keys
+                 completion:(RNCAsyncStorageResultCallback)block;
+
+- (void)setValues:(NSArray<NSString *> *)values
+          forKeys:(NSArray<NSString *> *)keys
+       completion:(RNCAsyncStorageResultCallback)block;
+
+- (void)valuesForKeys:(NSArray<NSString *> *)keys
+           completion:(RNCAsyncStorageResultCallback)block;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Summary:
---------
Adds a delegate property to `RNCAsyncStorage` to allow custom handling of storage.

Implements #33.

Test Plan:
----------
To manually test the delegate, shake the Simulator (^⌘Z) and toggle
"Set AsyncStorage Delegate". Otherwise, tests for JS have been duplicated for
the native delegate.