### PR TITLE
[Fix] Use same directory name for storage, couple of fixes

### DIFF
--- a/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
+++ b/example/ios/AsyncStorageExample.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		3D82E3B72248BD39001F5D1A /* libRNCAsyncStorage.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DC5398C220F2C940035D3A3 /* libRNCAsyncStorage.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 		ED297163215061F000B7C4FE /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED297162215061F000B7C4FE /* JavaScriptCore.framework */; };
@@ -327,6 +328,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3D82E3B72248BD39001F5D1A /* libRNCAsyncStorage.a in Frameworks */,
 				ED297163215061F000B7C4FE /* JavaScriptCore.framework in Frameworks */,
 				ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */,
 				11D1A2F320CAFA9E000508D9 /* libRCTAnimation.a in Frameworks */,

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -16,7 +16,7 @@
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
-static NSString *const RCTStorageDirectory = @"RNCAsyncLocalStorage_V1";
+static NSString *const RCTStorageDirectory = @"RCTAsyncLocalStorage_V1";
 static NSString *const RCTManifestFileName = @"manifest.json";
 static const NSUInteger RCTInlineValueThreshold = 1024;
 

--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -13,13 +13,21 @@
 
 const {NativeModules} = require('react-native');
 
-// Use RocksDB if available, then SQLite, then file storage.
-// Changed Name of SQLite DB, to not conflict with AsyncStorage from RN repo
 const RCTAsyncStorage =
-  NativeModules.AsyncRocksDBStorage ||
-  NativeModules.RNC_AsyncSQLiteDBStorage ||
-  NativeModules.RNCAsyncStorage ||
-  NativeModules.AsyncLocalStorage;
+  NativeModules.RNC_AsyncSQLiteDBStorage || NativeModules.RNCAsyncStorage;
+
+if (!RCTAsyncStorage) {
+  throw new Error(`@RNCommunity/AsyncStorage: NativeModule.RCTAsyncStorage is null.
+
+To fix this issue try these steps:
+  • Run \`react-native link @react-native-community/async-storage\` in the project root.
+  • Rebuild and re-run the app.
+  • Restart the packager with \`--clearCache\` flag.
+  • If you are using CocoaPods on iOS, run \`pod install\` in the \`ios\` directory and then rebuild and re-run the app.
+
+If none of these fix the issue, please open an issue on the Github repository: https://github.com/react-native-community/react-native-async-storage/issues 
+`);
+}
 
 type ReadOnlyArrayString = $ReadOnlyArray<string>;
 


### PR DESCRIPTION
Summary:
---------

Couple of things:

- Example was unlinked, so linked it back
- Uses same directory name as internal Async Storage, so transition is smooth
- Removed reference to RN's internal Async Storage - this sometimes thrown error `.multiMerge` error
- Throws error when not linked


Fixes #40 
Potentially fixes #44 

Test Plan:
----------

Green CI