### PR TITLE
Allow newer versions of RN to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "ci:publish": "yarn semantic-release"
   },
   "peerDependencies": {
-    "react": "^16.0",
-    "react-native": "^0.57.0"
+    "react": ">=16.0",
+    "react-native": ">=0.57.0"
   },
   "devDependencies": {
     "@babel/core": "7.0.0",
@@ -48,8 +48,8 @@
     "flow-bin": "0.86.0",
     "jest": "24.1.0",
     "metro-react-native-babel-preset": "0.51.1",
-    "react": "16.6.3",
-    "react-native": "0.58.4",
+    "react": ">=16.6.3",
+    "react-native": ">=0.58.4",
     "react-test-renderer": "16.6.3",
     "semantic-release": "15.13.3"
   },


### PR DESCRIPTION
Summary:
---------
Allows react-native versions higher than 0.58.4 to compile.


Test Plan:
----------
Simply run the app on react-native versions >=0.58.4.