### PR TITLE
fix: Fix Windows support

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -14,7 +14,9 @@
 const {NativeModules} = require('react-native');
 
 const RCTAsyncStorage =
-  NativeModules.RNC_AsyncSQLiteDBStorage || NativeModules.RNCAsyncStorage;
+  NativeModules.RNC_AsyncSQLiteDBStorage ||
+  NativeModules.RNCAsyncStorage ||
+  NativeModules.AsyncLocalStorage; // NativeModules.AsyncLocalStorage provides compatibility with out out tree platform
 
 if (!RCTAsyncStorage) {
   throw new Error(`@RNCommunity/AsyncStorage: NativeModule.RCTAsyncStorage is null.

--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -14,9 +14,9 @@
 const {NativeModules} = require('react-native');
 
 const RCTAsyncStorage =
+  NativeModules.AsyncLocalStorage || // Support for external modules, like react-native-windows
   NativeModules.RNC_AsyncSQLiteDBStorage ||
-  NativeModules.RNCAsyncStorage ||
-  NativeModules.AsyncLocalStorage; // NativeModules.AsyncLocalStorage provides compatibility with out out tree platform
+  NativeModules.RNCAsyncStorage;
 
 if (!RCTAsyncStorage) {
   throw new Error(`@RNCommunity/AsyncStorage: NativeModule.RCTAsyncStorage is null.


### PR DESCRIPTION
Summary:
---------

The [react-native-windows](https://github.com/Microsoft/react-native-windows) repo provides Windows build target support to React Native projects. It provides AsyncStorage support through the module name `AsyncLocalStorage` (exact file is [here](https://github.com/Microsoft/react-native-windows/blob/master/RNWCS/ReactWindows/ReactNative/Modules/Storage/AsyncStorageModule.cs)) but commit 547445c148b18be8bd1476d418e6f3318587b5cb removed the reference to `NativeModules.AsyncLocalStorage` from this repo which broke Windows support. This PR adds that back in.


Test Plan:
----------

Green CI