### PR TITLE
React Native peer dependency warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "react": "^16.0",
-    "react-native": "^0.59.0"
+    "react-native": ">=0.57"
   },
   "devDependencies": {
     "@babel/core": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "peerDependencies": {
     "react": "^16.0",
-    "react-native": "^0.57.0"
+    "react-native": "^0.59.0"
   },
   "devDependencies": {
     "@babel/core": "7.0.0",


### PR DESCRIPTION
Summary:
---------

`yarn add @react-native-community/async-storage`
when running rn 0.59.0 gives:

warning " > @react-native-community/async-storage@1.2.2" has incorrect peer dependency "react-native@^0.57.0".


Test Plan:
----------

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->