### PR TITLE
Update types to allow null return from multiget

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -51,8 +51,8 @@ declare module '@react-native-community/async-storage' {
      */
     multiGet(
       keys: string[],
-      callback?: (errors?: Error[], result?: [string, string][]) => void
-    ): Promise<[string, string][]>;
+      callback?: (errors?: Error[], result?: [string, string | null][]) => void
+    ): Promise<[string, string | null][]>;
 
     /**
      * multiSet and multiMerge take arrays of key-value array pairs that match the output of multiGet,


### PR DESCRIPTION
Per issue: https://github.com/react-native-community/react-native-async-storage/issues/58

`multiGet` types should allow returning `string | null`, not just string.

Summary:
---------

<!-- Thank you for sending the PR!
Help us understand more of your work - you can explain what you did, post a link to an issue etc. Anything helps! -->


Test Plan:
----------

<!-- Help us test your work (**REQUIRED**). If you changed the code, please provide us with instructions of how we can try it out ourselves, so we can confirm it's working. You can also post screenshots/gifts.  -->