### PR TITLE
fix: Prefer RNC's AsyncStorage over RN's.

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -14,9 +14,9 @@
 const {NativeModules} = require('react-native');
 
 const RCTAsyncStorage =
-  NativeModules.AsyncLocalStorage || // Support for external modules, like react-native-windows
   NativeModules.RNC_AsyncSQLiteDBStorage ||
-  NativeModules.RNCAsyncStorage;
+  NativeModules.RNCAsyncStorage ||
+  NativeModules.AsyncLocalStorage; // Support for external modules, like react-native-windows
 
 if (!RCTAsyncStorage) {
   throw new Error(`[@RNC/AsyncStorage]: NativeModule: AsyncStorage is null.


### PR DESCRIPTION
Summary:
---------
React Native's (deprecated) AsyncLocalStorage is being picked up before RNC's.

Test Plan:
----------
All the current tests should still pass.