### PR TITLE
iOS clean migration from RNCAsyncStorage_V1 to RTCAsyncStorage_V1

### DIFF
--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -101,7 +101,7 @@ static NSString *RCTGetStorageDirectory()
 
 static NSString *RCTCreateManifestFilePath(NSString *storageDirectory)
 {
-  return [RCTCreateStorageDirectoryPath(storageDirectory) stringByAppendingString:RCTManifestFileName];
+  return [RCTCreateStorageDirectoryPath(storageDirectory) stringByAppendingPathComponent:RCTManifestFileName];
 }
 
 static NSString *RCTGetManifestFilePath()

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -506,7 +506,7 @@ RCT_EXPORT_METHOD(multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
 }
 
 RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
-                  callback:(RCTResponseSenderBlock)callback)
+                    callback:(RCTResponseSenderBlock)callback)
 {
   if (self.delegate != nil) {
     NSMutableArray<NSString *> *keys = [NSMutableArray arrayWithCapacity:kvPairs.count];
@@ -640,4 +640,3 @@ RCT_EXPORT_METHOD(getAllKeys:(RCTResponseSenderBlock)callback)
 }
 
 @end
-

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -17,6 +17,7 @@
 #import <React/RCTUtils.h>
 
 static NSString *const RCTStorageDirectory = @"RCTAsyncLocalStorage_V1";
+static NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
 static NSString *const RCTManifestFileName = @"manifest.json";
 static const NSUInteger RCTInlineValueThreshold = 1024;
 
@@ -185,7 +186,6 @@ static NSDate *RCTManifestModificationDate(NSString *manifestFilePath)
   return [attributes fileModificationDate];
 }
 
-static NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
 /**
  * Creates an NSException used during Storage Directory Migration.
  */

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -185,7 +185,7 @@ static NSDate *RCTManifestModificationDate(NSString *manifestFilePath)
   return [attributes fileModificationDate];
 }
 
-NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
+static NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
 /**
  * Creates an NSException used during Storage Directory Migration.
  */

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -191,7 +191,7 @@ static NSString *const RCTOldStorageDirectory = @"RNCAsyncLocalStorage_V1";
  */
 static void RCTStorageDirectoryMigrationLogError(NSString *reason, NSError *error)
 {
-  NSLog(@"%@: %@", reason, error ? error.description : @"");
+  RCTLogWarn(@"%@: %@", reason, error ? error.description : @"");
 }
 
 static void RCTStorageDirectoryCleanupOld()

--- a/ios/RNCAsyncStorage.m
+++ b/ios/RNCAsyncStorage.m
@@ -535,7 +535,7 @@ RCT_EXPORT_METHOD(multiSet:(NSArray<NSArray<NSString *> *> *)kvPairs
 }
 
 RCT_EXPORT_METHOD(multiMerge:(NSArray<NSArray<NSString *> *> *)kvPairs
-                  callback:(RCTResponseSenderBlock)callback)
+                    callback:(RCTResponseSenderBlock)callback)
 {
   if (self.delegate != nil) {
     NSMutableArray<NSString *> *keys = [NSMutableArray arrayWithCapacity:kvPairs.count];
@@ -669,4 +669,3 @@ RCT_EXPORT_METHOD(getAllKeys:(RCTResponseSenderBlock)callback)
 }
 
 @end
-


### PR DESCRIPTION
Summary:
---------

See: https://github.com/react-native-community/react-native-async-storage/issues/55

Test Plan:
----------

The only type of tests I have already run is:
1. Hardcode set the variable `RCTStorageDirectory` to `RNCAsyncStorage_V1`
2. Run the app & set some values to cache
3. Close the app
4. Reset `RCTStorageDirectory` to `RCTAsyncStorage_V1`
5. Run the app and see that cached values have been migrated

I have performed these tests with and without a pre-existing storage directory and they work in both cases.

My only concerns are the way I am currently handling errors. If something goes wrong an `NSException` is thrown which will trigger a SIGABRT shutdown of the app since it is never caught. I am not extremely experienced with error handling in Objective-C so perhaps someone has some better ideas.