### PR TITLE
Deprecate AsyncStorage from React Native

### DIFF
--- a/lib/AsyncStorage.js
+++ b/lib/AsyncStorage.js
@@ -16,7 +16,7 @@ const {NativeModules} = require('react-native');
 const RCTAsyncStorage =
   NativeModules.RNC_AsyncSQLiteDBStorage ||
   NativeModules.RNCAsyncStorage ||
-  NativeModules.AsyncLocalStorage; // Support for external modules, like react-native-windows
+  NativeModules.PlatformLocalStorage; // Support for external modules, like react-native-windows
 
 if (!RCTAsyncStorage) {
   throw new Error(`[@RNC/AsyncStorage]: NativeModule: AsyncStorage is null.


### PR DESCRIPTION
Summary:
---------

From recent changes, we've moved back to add `LocalAsyncStorage` native module, which consequently fallbacks to deprecated Async Storage on RN Core.

This change reverts this back and add new name, to be used by external storages.


Test Plan:
----------

Green CI.