### PR TITLE
fix: Fixed failing to find headers when linked with Pods.

### DIFF
--- a/RNCAsyncStorage.podspec
+++ b/RNCAsyncStorage.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-async-storage"
+  s.name         = "RNCAsyncStorage"
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']

--- a/docs/Linking.md
+++ b/docs/Linking.md
@@ -14,10 +14,10 @@
 #### Using 'Pods'
 1. Enter into iOS Folder `cd ios/` (on your project's root folder).
 
-2. Add this line to your `Podfile` just below the last pod: (if you don't one just create a new runnning: `pod init`).
+2. Add this line to your `Podfile` just below the last pod (if you don't have one, you can create it by running `pod init`):
 
 ```diff
-+ pod 'react-native-async-storage', :path => '../node_modules/@react-native-community/async-storage'
++ pod 'RNCAsyncStorage', :path => '../node_modules/@react-native-community/async-storage'
 ```
 
 3. Run `pod install`


### PR DESCRIPTION
Summary:
---------

Multiple people have reported that RNCAsyncStorage fails to build after #35. See https://github.com/react-native-community/react-native-async-storage/pull/35#issuecomment-482604705, #73, and #74.

After a little discussion, we agreed to rename the `.podspec` and the name of the Pod to be more in line with Apple's naming guidelines and the rest of the community. Unfortunately, this means that the next upgrade will break.

I got a little impatient knowing that I broke the latest release so I went ahead and implemented the fix. Sorry if you've already started looking at this.

Test Plan:
----------

I used https://github.com/timmywil/react-native-async-storage-1.3.1, kindly provided by @timmywil, for testing.

Migration Plan:
---------------

Even though `react-native link` will be able to link the new `.podspec`, it won't clean up existing entries. Please find your Podfile, and make the following changes:

```diff
- pod 'react-native-async-storage', :path => '../node_modules/@react-native-community/async-storage'
+ pod 'RNCAsyncStorage', :path => '../node_modules/@react-native-community/async-storage'
```