### PR TITLE
Fix iOS Archive Issue

### DIFF
--- a/ios/RNCAsyncStorage.xcodeproj/project.pbxproj
+++ b/ios/RNCAsyncStorage.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1990B97A223993B0009E5EA1 /* RNCAsyncStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3E7B5881CC2AC0600A0062D /* RNCAsyncStorage.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		1990B97B223993B0009E5EA1 /* RNCAsyncStorageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1990B9402233FE3A009E5EA1 /* RNCAsyncStorageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1990B97A223993B0009E5EA1 /* RNCAsyncStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = B3E7B5881CC2AC0600A0062D /* RNCAsyncStorage.h */; };
+		1990B97B223993B0009E5EA1 /* RNCAsyncStorageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1990B9402233FE3A009E5EA1 /* RNCAsyncStorageDelegate.h */; };
 		B3E7B58A1CC2AC0600A0062D /* RNCAsyncStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNCAsyncStorage.m */; };
 /* End PBXBuildFile section */
 


### PR DESCRIPTION
Summary:
---------

I recently went ahead and upgraded my React & React-Native libraries to the latest versions. After completing that and other app changes (including moving away from [React-Native AsyncStorage](https://facebook.github.io/react-native/docs/asyncstorage)), I tried to archive my project and ran into an issue. When the app was archived, it would open the organizer and my app would be `Generic Xcode Archive` instead of the expected `iOS App Archive`.


Test Plan:
----------

Removed the two items that were in the 'public' section to the 'project' section solved my issue and app bundled (and was installed and used) without any issues.